### PR TITLE
remove celery dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,15 @@ except Exception as exc:
     # Что-то пошло не так
     raise
 ```
+
+### Периодическая проверка платежей по которым не известно состояние
+
+```python
+from datetime import timedelta
+from celery.task import periodic_task
+from sberbank.tasks import check_payments
+
+@periodic_task(run_every=timedelta(minutes=20))
+def task_check_payments():
+    check_payments()
+```

--- a/sberbank/tasks.py
+++ b/sberbank/tasks.py
@@ -1,13 +1,9 @@
-from datetime import timedelta
-
-from celery.task import periodic_task
 from django.conf import settings
 
 from sberbank.models import Payment, Status
 from sberbank.service import BankService
 
 
-@periodic_task(run_every=timedelta(minutes=20))
 def check_payments():
     unchecked_payments = Payment.objects.filter(
         status=Status.PENDING, bank_id__isnull=False)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setuptools.setup(
         'django',
         'django-jsonfield',
         'djangorestframework',
-        'celery',
         'requests',
     ],
     classifiers=[


### PR DESCRIPTION
Предлагаю не завязываться на Celery как единственный планировщик заданий.

В проекте может использоваться иной: https://github.com/coleifer/huey https://github.com/dbader/schedule and etc. даем пользователю выбор, добавил инструкцию в README
Сокращаем зависимости.