### PR TITLE
Added 'method' field to PaymentSerializer.Meta.fields

### DIFF
--- a/sberbank/serializers.py
+++ b/sberbank/serializers.py
@@ -26,4 +26,4 @@ class PaymentSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Payment
-        fields = ['uid', 'amount', 'status', 'updated', 'pan', 'system']
+        fields = ['uid', 'amount', 'status', 'updated', 'pan', 'system', 'method']


### PR DESCRIPTION
DRF (at least version 3.9.x) raises exception 

```
AssertionError at /sberbank/payment/history/1/  
The field 'method' was declared on serializer PaymentSerializer, but has not been included in the 'fields' option.
```